### PR TITLE
Allow providing Value Types and non generic overloads

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,11 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v2
 
+            - name: Setup .NET Core
+              uses: actions/setup-dotnet@v2
+              with:
+                  global-json-file: global.json
+
             - name: Build
               run: dotnet build ./src/FakeItEasy.AutoFakeIt/FakeItEasy.AutoFakeIt.csproj --configuration Release
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
               run: dotnet test ./tests/FakeItEasy.AutoFakeIt.UnitTests/FakeItEasy.AutoFakeIt.UnitTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput='./../../coverage/'
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v1.2.1
+              uses: codecov/codecov-action@v3
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   directory: ./coverage/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 5.0.301
+            global-json-file: global.json
 
       - name: publish FakeItEasy.AutoFakeIt
         id: publish_nuget_common

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.301",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/FakeItEasy.AutoFakeIt/AutoFakeIt.cs
+++ b/src/FakeItEasy.AutoFakeIt/AutoFakeIt.cs
@@ -20,12 +20,12 @@ namespace FakeItEasy.AutoFakeIt
         /// <returns>A class with all its dependencies faked.</returns>
         /// <exception cref="ArgumentException">Throws an ArgumentException if we can't find a public constructor
         /// with "fakeable" dependencies.</exception>
-        public T Generate<T>() where T : class => (T)Generate(typeof(T));
+        public T Generate<T>() where T : notnull => (T)Generate(typeof(T));
 
         /// <summary>
-        /// Generates a object automatically injecting FakeItEasy's fakes for all its dependencies.
+        /// Generates an object of the specified type automatically injecting FakeItEasy's fakes for all its dependencies.
         /// </summary>
-        /// <param name="type">The class you want to generate, usually your System Under Test.</param>
+        /// <param name="type">The type of the class you want to generate, usually your System Under Test.</param>
         /// <returns>A class with all its dependencies faked.</returns>
         /// <exception cref="ArgumentException">Throws an ArgumentException if we can't find a public constructor
         /// with "fakeable" dependencies.</exception>
@@ -87,17 +87,10 @@ namespace FakeItEasy.AutoFakeIt
         /// </summary>
         /// <typeparam name="T">The fake object you want to retrieve.</typeparam>
         /// <returns>An object of the given type, either previously provided or a new one just generated with FakeItEasy.</returns>
-        public T Resolve<T>() where T : notnull
-        {
-            if (_fakedObjects.ContainsKey(typeof(T)))
-                return (T)_fakedObjects[typeof(T)];
-
-            _fakedObjects[typeof(T)] = A.Fake<T>();
-            return (T)_fakedObjects[typeof(T)];
-        }
+        public T Resolve<T>() where T : notnull => (T)Resolve(typeof(T));
 
         /// <summary>
-        /// Returns the object used for <param name="type" />. If an object of the given type was not explicitly
+        /// Returns the object used for the type passed. If an object of the given type was not explicitly
         /// provided, it will create a FakeItEasy's fake that will be used for all subsequent calls.
         /// </summary>
         /// <returns>An object of the given type, either previously provided or a new one just generated with FakeItEasy.</returns>
@@ -105,9 +98,11 @@ namespace FakeItEasy.AutoFakeIt
         {
             if (_fakedObjects.ContainsKey(type))
                 return _fakedObjects[type];
-
-            _fakedObjects[type] = Create.Fake(type);
-            return _fakedObjects[type];
+            else
+            {
+                _fakedObjects[type] = Create.Fake(type);
+                return _fakedObjects[type];
+            }
         }
 
 
@@ -127,6 +122,7 @@ namespace FakeItEasy.AutoFakeIt
         /// <see cref="Resolve"/> or for a dependency on <see cref="Generate"/>. </summary>
         /// <remarks><para>This is useful for providing your own specific instance of a type, either because you can't
         /// use an automatically generated fake, or because you have a concrete type that you prefer to use.</para>
+        /// <param name="registerType">The type of the object you want to provide.</param>
         /// <param name="dependency">The object you want to set.</param>
         /// <para>It will override any previously registered object of the same type of <param name="registerType"/>.</para></remarks>
         /// <exception cref="ArgumentException">Throws an ArgumentException if dependency is not assignable to registerType.</exception>

--- a/src/FakeItEasy.AutoFakeIt/AutoFakeIt.cs
+++ b/src/FakeItEasy.AutoFakeIt/AutoFakeIt.cs
@@ -20,9 +20,18 @@ namespace FakeItEasy.AutoFakeIt
         /// <returns>A class with all its dependencies faked.</returns>
         /// <exception cref="ArgumentException">Throws an ArgumentException if we can't find a public constructor
         /// with "fakeable" dependencies.</exception>
-        public T Generate<T>() where T : class
+        public T Generate<T>() where T : class => (T)Generate(typeof(T));
+
+        /// <summary>
+        /// Generates a object automatically injecting FakeItEasy's fakes for all its dependencies.
+        /// </summary>
+        /// <param name="type">The class you want to generate, usually your System Under Test.</param>
+        /// <returns>A class with all its dependencies faked.</returns>
+        /// <exception cref="ArgumentException">Throws an ArgumentException if we can't find a public constructor
+        /// with "fakeable" dependencies.</exception>
+        public object Generate(Type type)
         {
-            var constructors = typeof(T).GetConstructors()
+            var constructors = type.GetConstructors()
                 .OrderByDescending(ctor => ctor.GetParameters().Length)
                 .ToList();
 
@@ -33,7 +42,7 @@ namespace FakeItEasy.AutoFakeIt
                 {
                     var candidateFakeObjects = GenerateCandidateFakeObjects(ctor);
 
-                    var generatedObject = (T)ctor.Invoke(candidateFakeObjects.Values.ToArray());
+                    var generatedObject = ctor.Invoke(candidateFakeObjects.Values.ToArray());
 
                     InsertMissingFakedObjects(candidateFakeObjects);
 
@@ -46,8 +55,9 @@ namespace FakeItEasy.AutoFakeIt
                 }
             }
 
-            throw new ArgumentException($"No suitable constructor found for type '{typeof(T)}'.", lastThrownException);
+            throw new ArgumentException($"No suitable constructor found for type '{type}'.", lastThrownException);
         }
+
 
         private Dictionary<Type, object> GenerateCandidateFakeObjects(ConstructorInfo ctor)
         {
@@ -81,12 +91,25 @@ namespace FakeItEasy.AutoFakeIt
         {
             if (_fakedObjects.ContainsKey(typeof(T)))
                 return (T)_fakedObjects[typeof(T)];
-            else
-            {
-                _fakedObjects[typeof(T)] = A.Fake<T>();
-                return (T)_fakedObjects[typeof(T)];
-            }
+
+            _fakedObjects[typeof(T)] = A.Fake<T>();
+            return (T)_fakedObjects[typeof(T)];
         }
+
+        /// <summary>
+        /// Returns the object used for <param name="type" />. If an object of the given type was not explicitly
+        /// provided, it will create a FakeItEasy's fake that will be used for all subsequent calls.
+        /// </summary>
+        /// <returns>An object of the given type, either previously provided or a new one just generated with FakeItEasy.</returns>
+        public object Resolve(Type type)
+        {
+            if (_fakedObjects.ContainsKey(type))
+                return _fakedObjects[type];
+
+            _fakedObjects[type] = Create.Fake(type);
+            return _fakedObjects[type];
+        }
+
 
         /// <summary>
         /// Explicitly sets an object to use when someone asks for an object of the given type, either on a
@@ -97,12 +120,26 @@ namespace FakeItEasy.AutoFakeIt
         /// <param name="dependency">The object you want to set.</param>
         /// <typeparam name="T">The type of the object you want to register it as. You can set an object for a specific
         /// type, for example, you can provide an object to be used when someone asks for an interface.</typeparam>
-        public void Provide<T>(T dependency) where T : notnull
+        public void Provide<T>(T dependency) where T : notnull => Provide(typeof(T), dependency);
+
+        /// <summary>
+        /// Explicitly sets an object to use when someone asks for an object of the given type, either on a
+        /// <see cref="Resolve"/> or for a dependency on <see cref="Generate"/>. </summary>
+        /// <remarks><para>This is useful for providing your own specific instance of a type, either because you can't
+        /// use an automatically generated fake, or because you have a concrete type that you prefer to use.</para>
+        /// <param name="dependency">The object you want to set.</param>
+        /// <para>It will override any previously registered object of the same type of <param name="registerType"/>.</para></remarks>
+        /// <exception cref="ArgumentException">Throws an ArgumentException if dependency is not assignable to registerType.</exception>
+        public void Provide(Type registerType, object dependency)
         {
-            if (_fakedObjects.ContainsKey(typeof(T)))
-                _fakedObjects[typeof(T)] = dependency;
+            if (!registerType.IsInstanceOfType(dependency))
+                throw new ArgumentException(
+                    $"Dependency type '{registerType}' is not assignable to '{dependency.GetType()}'.");
+
+            if (_fakedObjects.ContainsKey(registerType))
+                _fakedObjects[registerType] = dependency;
             else
-                _fakedObjects.Add(typeof(T), dependency);
+                _fakedObjects.Add(registerType, dependency);
         }
     }
 }

--- a/src/FakeItEasy.AutoFakeIt/AutoFakeIt.cs
+++ b/src/FakeItEasy.AutoFakeIt/AutoFakeIt.cs
@@ -77,7 +77,7 @@ namespace FakeItEasy.AutoFakeIt
         /// </summary>
         /// <typeparam name="T">The fake object you want to retrieve.</typeparam>
         /// <returns>An object of the given type, either previously provided or a new one just generated with FakeItEasy.</returns>
-        public T Resolve<T>() where T : class
+        public T Resolve<T>() where T : notnull
         {
             if (_fakedObjects.ContainsKey(typeof(T)))
                 return (T)_fakedObjects[typeof(T)];
@@ -97,7 +97,7 @@ namespace FakeItEasy.AutoFakeIt
         /// <param name="dependency">The object you want to set.</param>
         /// <typeparam name="T">The type of the object you want to register it as. You can set an object for a specific
         /// type, for example, you can provide an object to be used when someone asks for an interface.</typeparam>
-        public void Provide<T>(T dependency) where T : class
+        public void Provide<T>(T dependency) where T : notnull
         {
             if (_fakedObjects.ContainsKey(typeof(T)))
                 _fakedObjects[typeof(T)] = dependency;

--- a/src/FakeItEasy.AutoFakeIt/FakeItEasy.AutoFakeIt.csproj
+++ b/src/FakeItEasy.AutoFakeIt/FakeItEasy.AutoFakeIt.csproj
@@ -18,7 +18,7 @@
         <RepositoryType>Git</RepositoryType>
         <PackageTags>fakeiteasy, unit-testing, nunit, xunit, mstest</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Company/>
+        <Company />
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -32,7 +32,7 @@
         <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="FakeItEasy" Version="4.0.0"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+        <PackageReference Include="FakeItEasy" Version="4.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
 </Project>

--- a/tests/FakeItEasy.AutoFakeIt.UnitTests/FakeItEasy.AutoFakeIt.UnitTests.csproj
+++ b/tests/FakeItEasy.AutoFakeIt.UnitTests/FakeItEasy.AutoFakeIt.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/tests/FakeItEasy.AutoFakeIt.UnitTests/Specs/AutoFakeItNonGenericTests.cs
+++ b/tests/FakeItEasy.AutoFakeIt.UnitTests/Specs/AutoFakeItNonGenericTests.cs
@@ -1,0 +1,175 @@
+using FakeItEasy.AutoFakeIt.UnitTests.Stubs;
+using FakeItEasy.Core;
+using FluentAssertions;
+using NUnit.Framework;
+using System;
+
+namespace FakeItEasy.AutoFakeIt.UnitTests.Specs
+{
+    public class AutoFakeItTestsNonGeneric
+    {
+        [Test]
+        public void GenerateShouldReturnAnInstanceOfClassWithoutDependencies()
+        {
+            var sut = new AutoFakeIt().Generate(typeof(SimpleSut));
+
+            sut.Should().NotBeNull();
+        }
+
+        [Test]
+        public void GenerateShouldThrowExceptionWhenClassHasNoConstructorsWithFakeableParameters()
+        {
+            Action act = () => new AutoFakeIt().Generate(typeof(UnfakeableSut));
+
+            act.Should().Throw<ArgumentException>()
+                .WithMessage($"No suitable constructor found for type '{typeof(UnfakeableSut).FullName}'.")
+                .WithInnerException<FakeCreationException>();
+        }
+
+        [Test]
+        public void GenerateShouldReturnAnInstanceOfClassWithFakedDependencies()
+        {
+            var sut = (DependenciesSut)new AutoFakeIt().Generate(typeof(DependenciesSut));
+
+            sut.Should().NotBeNull();
+            A.CallTo(() => sut.DependencyA.Method()).Returns("Faked");
+            sut.DependencyA.Method().Should().Be("Faked");
+        }
+
+        [Test]
+        public void GenerateShouldReturnAnInstanceOfClassWithSubdependencies()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var sut = (SubdependenciesSut)autoFakeIt.Generate(typeof(SubdependenciesSut));
+
+            sut.Should().NotBeNull();
+            A.CallTo(() => sut.Dependency.Subdependency.Method()).Returns("Faked");
+            sut.Dependency.Subdependency.Method().Should().Be("Faked");
+        }
+
+        [Test]
+        public void GenerateShouldReturnAnInstanceOfClassWithSubdependenciesDespiteItsOrder()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            autoFakeIt.Resolve(typeof(Dependency));
+            var sut = autoFakeIt.Generate(typeof(SubdependenciesSut));
+
+            sut.Should().NotBeNull();
+        }
+
+        [Test]
+        public void GenerateShouldReturnAnInstanceOfClassWithTheMostFakedDependenciesPossible()
+        {
+            var sut = (MultipleConstructorsSut)new AutoFakeIt().Generate(typeof(MultipleConstructorsSut));
+
+            sut.Should().NotBeNull();
+            A.CallTo(() => sut.DependencyB.Method()).Returns("Faked");
+            sut.DependencyB.Method().Should().Be("Faked");
+        }
+
+        [Test]
+        public void GenerateShouldReusePreviouslyResolvedType()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var depA = autoFakeIt.Resolve(typeof(DependencyA));
+            var sut = (DependenciesSut)autoFakeIt.Generate(typeof(DependenciesSut));
+
+            sut.DependencyA.Should().Be(depA);
+        }
+
+        [Test]
+        public void ResolveShouldReturnGeneratedFakeTypes()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var sut = (DependenciesSut)autoFakeIt.Generate(typeof(DependenciesSut));
+
+            autoFakeIt.Resolve(typeof(DependencyA)).Should().Be(sut.DependencyA);
+        }
+
+        [Test]
+        public void ResolveShouldGenerateAndReturnAFakeTypeWhenNoneIsAvailable()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var depA = (DependencyA)autoFakeIt.Resolve(typeof(DependencyA));
+
+            depA.Should().NotBeNull();
+            A.CallTo(() => depA.Method()).Returns("Faked");
+            depA.Method().Should().Be("Faked");
+        }
+
+        [Test]
+        public void ResolveShouldReturnProvidedDependency()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var depA = new DependencyA();
+            autoFakeIt.Provide(depA.GetType(), depA);
+
+            autoFakeIt.Resolve(typeof(DependencyA)).Should().Be(depA);
+        }
+
+        [Test]
+        public void ResolveShouldReturnProvidedValueTypeDependency()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var structDep = new ValueDependency();
+            autoFakeIt.Provide(structDep.GetType(), structDep);
+
+            autoFakeIt.Resolve(typeof(ValueDependency)).Should().Be(structDep);
+        }
+
+        [Test]
+        public void GenerateShouldReturnProvidedValueTypeDependency()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var structDep = new ValueDependency();
+            autoFakeIt.Provide(structDep.GetType(), structDep);
+
+            var generated = (StructDependenciesSut)autoFakeIt.Generate(typeof(StructDependenciesSut));
+            generated.ValueDependency.Should().Be(structDep);
+        }
+
+        [Test]
+        public void ResolveShouldUpdateProvidedDependencyWhenOneIsAlreadyAvailable()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var depA = new DependencyA();
+            autoFakeIt.Provide(depA.GetType(), depA);
+            var depA2 = new DependencyA();
+            autoFakeIt.Provide(depA.GetType(), depA2);
+
+            autoFakeIt.Resolve(typeof(DependencyA)).Should().Be(depA2);
+        }
+
+        [Test]
+        public void ResolveShouldReturnObjectsRegisteredWithExplicitTypes()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var depA = new DependencyA();
+            autoFakeIt.Provide(typeof(IDependencyA), depA);
+
+            autoFakeIt.Resolve(typeof(IDependencyA)).Should().Be(depA);
+        }
+
+        [Test]
+        public void GenerateShouldUseProvidedDependency()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var depA = new DependencyA();
+            autoFakeIt.Provide(typeof(DependencyA), depA);
+
+            var sut = (DependenciesSut)autoFakeIt.Generate(typeof(DependenciesSut));
+            sut.DependencyA.Should().Be(depA);
+        }
+
+        [Test]
+        public void ProvideShouldThrowExceptionWhenDependencyIsNotAssignableToRegisterType()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var depA = new DependencyA();
+            var act = () => autoFakeIt.Provide(typeof(DependencyB), depA);
+
+            act.Should().Throw<ArgumentException>()
+             .WithMessage($"Dependency type '{typeof(DependencyB).FullName}' is not assignable to '{typeof(DependencyA).FullName}'.");
+        }
+    }
+}

--- a/tests/FakeItEasy.AutoFakeIt.UnitTests/Specs/AutoFakeItTests.cs
+++ b/tests/FakeItEasy.AutoFakeIt.UnitTests/Specs/AutoFakeItTests.cs
@@ -108,6 +108,26 @@ namespace FakeItEasy.AutoFakeIt.UnitTests.Specs
         }
 
         [Test]
+        public void ResolveShouldReturnProvidedValueTypeDependency()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var structDep = new ValueDependency();
+            autoFakeIt.Provide(structDep);
+
+            autoFakeIt.Resolve<ValueDependency>().Should().Be(structDep);
+        }
+
+        [Test]
+        public void GenerateShouldReturnProvidedValueTypeDependency()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var structDep = new ValueDependency();
+            autoFakeIt.Provide(structDep);
+
+            autoFakeIt.Generate<StructDependenciesSut>().ValueDependency.Should().Be(structDep);
+        }
+
+        [Test]
         public void ResolveShouldUpdateProvidedDependencyWhenOneIsAlreadyAvailable()
         {
             var autoFakeIt = new AutoFakeIt();

--- a/tests/FakeItEasy.AutoFakeIt.UnitTests/Specs/AutoFakeItTests.cs
+++ b/tests/FakeItEasy.AutoFakeIt.UnitTests/Specs/AutoFakeItTests.cs
@@ -159,5 +159,16 @@ namespace FakeItEasy.AutoFakeIt.UnitTests.Specs
             var sut = autoFakeIt.Generate<DependenciesSut>();
             sut.DependencyA.Should().Be(depA);
         }
+
+        [Test]
+        public void GenericResolveShouldWorkWithNonGenericProvide()
+        {
+            var autoFakeIt = new AutoFakeIt();
+            var depA = new DependencyA();
+            autoFakeIt.Provide(typeof(DependencyA), depA);
+
+            var resolvedDepA = autoFakeIt.Resolve<DependencyA>();
+            resolvedDepA.Should().NotBeNull();
+        }
     }
 }

--- a/tests/FakeItEasy.AutoFakeIt.UnitTests/Stubs/StructDependenciesSut.cs
+++ b/tests/FakeItEasy.AutoFakeIt.UnitTests/Stubs/StructDependenciesSut.cs
@@ -1,0 +1,23 @@
+namespace FakeItEasy.AutoFakeIt.UnitTests.Stubs
+{
+    public struct ValueDependency
+    {
+        public string Value { get; }
+        public ValueDependency()
+        {
+            Value = System.Guid.NewGuid().ToString();
+        }
+    }
+
+    public class StructDependenciesSut
+    {
+        public ValueDependency ValueDependency { get; }
+        public DependencyA DependencyA { get; }
+
+        public StructDependenciesSut(DependencyA dependencyA, ValueDependency valueDependency)
+        {
+            ValueDependency = valueDependency;
+            DependencyA = dependencyA;
+        }
+    }
+}


### PR DESCRIPTION
Not allowing the provision of value types restricts some cases like receiving a `DateTime` or `CancelationToken` as a dependency